### PR TITLE
Fix LED color index for orange status

### DIFF
--- a/Firmware/baby_mon/src/main.c
+++ b/Firmware/baby_mon/src/main.c
@@ -50,7 +50,7 @@
 #define COLOR_BLUE 2
 #define COLOR_BLACK 3
 #define COLOR_WHITE 4
-#define COLOR_ORANGE 4
+#define COLOR_ORANGE 5
 
 uint8_t sphr_data[8];
 


### PR DESCRIPTION
## Summary
- fix incorrect COLOR_ORANGE constant in firmware

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d3064cec832fa7c0c96308513c9d